### PR TITLE
Updated translations from lokalise on Sat Dec 27 14:50:21 PST 2025

### DIFF
--- a/RileyLinkKitUI/Localizable.xcstrings
+++ b/RileyLinkKitUI/Localizable.xcstrings
@@ -620,13 +620,13 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery level"
           }
         },
         "ce" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery level"
           }
         },
@@ -650,7 +650,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery level"
           }
         },
@@ -668,7 +668,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery level"
           }
         },
@@ -704,7 +704,7 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery level"
           }
         },
@@ -746,7 +746,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery level"
           }
         }
@@ -967,7 +967,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Connected"
           }
         },
@@ -3822,13 +3822,13 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Off"
           }
         },
         "ce" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Off"
           }
         },
@@ -3870,7 +3870,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Off"
           }
         },
@@ -3906,7 +3906,7 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Off"
           }
         },
@@ -3948,7 +3948,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Off"
           }
         }
@@ -3959,13 +3959,13 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "On"
           }
         },
         "ce" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "On"
           }
         },
@@ -4007,7 +4007,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "On"
           }
         },


### PR DESCRIPTION
All changes are of the "No value added" variety.

"No value added" means:
* A key that was marked as "new" is marked as "translated" 
   * the key is not actually translated; it is same as source (English copied into the translated field for some languages) 
* If we later want to clean these up, we need to make the change in Xcode and then upload to lokalise with the `--replace-modified` field
* For now, just accept so that next import will be clean